### PR TITLE
Limit pushes to iOS

### DIFF
--- a/connectors/parse/base.py
+++ b/connectors/parse/base.py
@@ -23,7 +23,6 @@ class ParseWrapper:
             'X-Parse-REST-API-Key': c['parse_rest_api_key'],
             'Content-Type': 'application/json'
         }
-        self.default_channels = c['parse_default_channels']
         self.base_uri = 'https://api.parse.com/1'
 
     def push (self, alert, action, identifier):
@@ -33,7 +32,9 @@ class ParseWrapper:
         '''
         payload = \
         {
-            "where": {},
+            "where": {
+              "deviceType": "ios"
+            },
             "data" : {
                 "action": action,
                 "aps": {


### PR DESCRIPTION
As Android and Windows phones will be using the same keys for action
alert pushes, but don't support sharknado content yet.
